### PR TITLE
Remove unused jdk8 classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,11 @@ Like the original `S3_PING`, this library implement a JGroups `Discovery` protoc
         bucketPrefix="jgroups"/>
 ```
 
+`NATIVE_S3_PING` automatically registers itself to JGroups with the magic number 789. You can overwrite this by
+setting the system property `s3ping.magic_number` to different number:
+
+`-Ds3ping.magic_number=123`
+
 ## Possible Configurations
 
 * **regionName**: like "eu-west-1", "us-east-1", etc.

--- a/README.md
+++ b/README.md
@@ -23,12 +23,6 @@ Like the original `S3_PING`, this library implement a JGroups `Discovery` protoc
         bucketPrefix="jgroups"/>
 ```
 
-To be able to use this configuration in your application, you have to initialize the plugin in your code:
-
-```java
-NATIVE_S3_PING.registerProtocolWithJGroups();
-```
-
 ## Possible Configurations
 
 * **regionName**: like "eu-west-1", "us-east-1", etc.

--- a/pom.xml
+++ b/pom.xml
@@ -48,14 +48,14 @@
         <dependency>
             <groupId>org.jgroups</groupId>
             <artifactId>jgroups</artifactId>
-            <version>3.6.1.Final</version>
+            <version>3.6.3.Final</version>
             <scope>provided</scope>
         </dependency>
 
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.9.9</version>
+            <version>1.9.39</version>
         </dependency>
 
         <!-- testing -->

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,15 @@
                     <releaseProfiles>release</releaseProfiles>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.18.1</version>
+                <configuration>
+                    <argLine>-Djava.net.preferIPv4Stack=true</argLine>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/src/main/java/de/zalando/jgroups/NATIVE_S3_PING.java
+++ b/src/main/java/de/zalando/jgroups/NATIVE_S3_PING.java
@@ -44,6 +44,10 @@ public class NATIVE_S3_PING extends FILE_PING {
 
     private AmazonS3 s3;
 
+    static {
+        registerProtocolWithJGroups();
+    }
+
     @Override
     public void init() throws Exception {
         super.init();

--- a/src/main/java/de/zalando/jgroups/NATIVE_S3_PING.java
+++ b/src/main/java/de/zalando/jgroups/NATIVE_S3_PING.java
@@ -14,8 +14,6 @@ import org.jgroups.util.Responses;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 /**
@@ -31,7 +29,6 @@ public class NATIVE_S3_PING extends FILE_PING {
 
     private static final int SERIALIZATION_BUFFER_SIZE = 4096;
     private static final String SERIALIZED_CONTENT_TYPE = "text/plain";
-    private static final Duration EXPIRATION_DURATION = Duration.of(10, ChronoUnit.SECONDS);
 
     @Property(description = "The S3 endpoint to use (optional).", exposeAsManagedAttribute = false)
     protected String endpoint;

--- a/src/test/java/de/zalando/jgroups/NativeS3PingTest.java
+++ b/src/test/java/de/zalando/jgroups/NativeS3PingTest.java
@@ -13,7 +13,6 @@ public class NativeS3PingTest {
 
     @Test
     public void findMembersTest() {
-        NATIVE_S3_PING.registerProtocolWithJGroups();
 
         final List<ClusterMember> members = new ArrayList<ClusterMember>();
         for (int n = 0; n < MEMBER_COUNT; n++) {

--- a/src/test/java/de/zalando/jgroups/NativeS3PingTest.java
+++ b/src/test/java/de/zalando/jgroups/NativeS3PingTest.java
@@ -4,8 +4,8 @@ import org.jgroups.JChannel;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 public class NativeS3PingTest {
@@ -16,7 +16,7 @@ public class NativeS3PingTest {
 
         final List<ClusterMember> members = new ArrayList<ClusterMember>();
         for (int n = 0; n < MEMBER_COUNT; n++) {
-            members.add(new ClusterMember("findMembersTest-" + Instant.now().getEpochSecond()));
+            members.add(new ClusterMember("findMembersTest-" + (new Date().getTime()) / 1000));
         }
 
         for (final ClusterMember member: members) {


### PR DESCRIPTION
Hi,

we made a few changes that allows us to use the library in our project:
1. Removed EXPIRATION_DURATION
It was not used but used classes only available in JDK8. Without it the library can be run with JDK 6 and 7.
2. Put registerProtocolWithJGroups call in a static code block
This way it is automatically registered without needing to call it from your application (what is a bit complicated if you just want to run a WAR in tomcat).
3. Some smaller changes to pom.xml:
* Using newer dependencies
* Make junits tests work with activated IPv6 stack).